### PR TITLE
Added ability to control output details

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -32,8 +32,8 @@ function shouldItRun(config) {
                 }
                 if( config.outputSummary ) {
                     var summary = summariser(results);
-                    for(var i = 0; i < summary.length; i++) {
-                        console.log(summary[i]);
+                    for(var j = 0; j < summary.length; j++) {
+                        console.log(summary[j]);
                     }
                 }
             } catch(e) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,6 +11,7 @@ function shouldItRun(config) {
         resultCollector = require('../lib/resultCollector'),
         inspector = require('../lib/inspector'),
         spitterOuter = require('../lib/spitterOuter'),
+        summariser = require('../lib/summariser'),
         XmlWriter = require('../lib/junitXmlWriter'),
         fs = require('fs');
 
@@ -25,9 +26,15 @@ function shouldItRun(config) {
                 var results = inspector(files, config);
                 var writer = new XmlWriter(config);
                 writer.writeResults(results);
-                var output = spitterOuter(results);
+                var output = spitterOuter(results,config);
                 for (var i = 0; i < output.length; i++) {
                     console.log(output[i]);
+                }
+                if( config.outputSummary ) {
+                    var summary = summariser(results);
+                    for(var i = 0; i < summary.length; i++) {
+                        console.log(summary[i]);
+                    }
                 }
             } catch(e) {
                 if (config.watch) {

--- a/lib/configBuilder.js
+++ b/lib/configBuilder.js
@@ -108,7 +108,7 @@ function buildConfig(args) {
     if (config.results && typeof config.results === 'string') {
         config.results = [config.results];
     }
-    if(config.outputDetails && !(typeof config.outputDetails == 'Object') ) {
+    if(config.outputDetails && typeof config.outputDetails != 'object' ) {
         config.outputDetails = config.outputDetails.split(',');
     }
     config.outputSumary = !!config.outputSummary;

--- a/lib/configBuilder.js
+++ b/lib/configBuilder.js
@@ -40,6 +40,8 @@ function buildConfig(args) {
         specs: false,
         results: false,
         hint: false,
+        outputDetails: 'failed,passed,pending',
+        outputSummary: false,
         tags: [],
         'junit-out': 'junit-output.xml',
         'specs-out': 'spec-file.json',
@@ -81,6 +83,8 @@ function buildConfig(args) {
             '  --watch Start in watch mode.\n' +
             '  --specs="<glob>" Feature files to read (eg "*/**/*.feature.md").\n' +
             '  --results="<glob>" Comma-deliminated list of test output (eg "tests/*.xml,tests/*.json").\n' +
+            '  --outputSummary="<bool>" Enable / Disable output summary.\n' +
+            '  --outputDetails="<states>" Comma-delinated list of test states to display (passed,failed,pending).\n' +
             '  --tags=<tags> Comma-delinated list of tagged features to read.\n' +
             '  --junit-out=<file> File name for junit output (default: junit-output.xml).\n' +
             '  --specs-out=<file> File name for spec json output (default: spec-file.json).\n' +
@@ -104,7 +108,10 @@ function buildConfig(args) {
     if (config.results && typeof config.results === 'string') {
         config.results = [config.results];
     }
-
+    if(config.outputDetails && !(typeof config.outputDetails == 'Object') ) {
+        config.outputDetails = config.outputDetails.split(',');
+    }
+    config.outputSumary = !!config.outputSummary;
     /**
      * We ALWAYS need spec files and tests results.
      */

--- a/lib/spitterOuter.js
+++ b/lib/spitterOuter.js
@@ -19,6 +19,7 @@ function spitterOuter(input, config) {
         };
 
     for (status in stateColors) {
+        if( config.outputDetails.indexOf(status) < 0 ){ continue; }
         if( stateColors.hasOwnProperty( status ) ) {
             coloriseInput(stateColors[status], input[status], callback);
         } 

--- a/lib/summariser.js
+++ b/lib/summariser.js
@@ -1,0 +1,65 @@
+var colors = require('colors');
+
+/**
+ * "summariser"
+ *
+ * Renders summary output of passes, failures, unimplemented and line numbers.
+ */
+function summariser(results) {
+    var response = [],
+        callback = function(output) {
+            response.push(output);
+        };
+
+    var passed = 0;  
+    if( results.hasOwnProperty('passed') ) {
+        passed = countSpecs(results.passed);
+    }
+    var failed = 0;
+    if(results.hasOwnProperty('failed')) {
+       failed = countSpecs(results.failed);
+    }
+    var pending = 0 ;
+    
+    if(results.hasOwnProperty('pending')) {
+        pending = countSpecs(results.pending);
+    }
+    var total = passed+failed+pending;
+
+    coloriseOutput(total+' Specs defined','bold',callback);
+    if(total > 0) {
+        coloriseOutput(passed+' Passed' + displayPercentage(total, passed),'green', callback);
+        coloriseOutput(failed + ' Failed' + displayPercentage(total, failed),'red', callback);
+        coloriseOutput(pending + ' Pending' + displayPercentage(total, pending),'yellow', callback);
+    }
+    return response;
+}
+
+function displayPercentage(total, value){
+    if( total < 1 ){ return ''; }
+    return ' (' + ( (value/total) *100).toFixed(1) + '%)';
+}
+
+function coloriseOutput(string,colour,callback){
+    callback(string[colour]);
+}
+
+function countSpecs(specList) {
+    var count = 0;
+    for(i = 0; i < specList.length; i += 1) {
+        for(var key in specList[i]) {
+            if(typeof specList[i][key] === "string") {
+                count++;
+            } else {
+                for(var suite in specList[i][key]) {
+                    if(specList[i][key].hasOwnProperty(suite)) {
+                        count++;
+                    }
+                }
+            }
+        }
+    }
+    return count;
+};
+
+module.exports = summariser;

--- a/lib/summariser.js
+++ b/lib/summariser.js
@@ -60,6 +60,6 @@ function countSpecs(specList) {
         }
     }
     return count;
-};
+}
 
 module.exports = summariser;

--- a/test/configBuilderSpec.js
+++ b/test/configBuilderSpec.js
@@ -56,4 +56,16 @@ describe ("Config Builder", function () {
         fs.unlinkSync('myfile.json');
     });
 
+    it("should be able take instruction on outputting summary information", function() {
+        args[4] = '--outputSummary=0';
+        assert.equal(buildConfig(args).outputSummary, false);
+        args[4] = '--outputSummary=1';
+        assert.equal(buildConfig(args).outputSummary, true);
+    });
+    
+    it("should be able to add a comma deliminated outputDetails", function() {
+        args[4] = "--outputDetails=passed,failed";
+        assert.deepEqual(buildConfig(args).outputDetails, ['passed','failed']);
+    });
+
 });

--- a/test/spitterOuterSpec.js
+++ b/test/spitterOuterSpec.js
@@ -9,8 +9,10 @@
                 passed: [{"This has passed" : "line"}, {"This Suite": {"has also passed": "line"}}],
                 failed: [{"This has failed" : "line"}],
                 pending: [{"This is pending" : "line"}]
+            }, config = {
+                "outputDetails": ["failed","passed","pending"]
             },
-            result = spitterOuter(input);
+            result = spitterOuter(input,config);
 
             assert.equal(result[0], "\u001b[32mThis has passed\u001b[39m");
             assert.equal(result[1], "\u001b[90mline\u001b[39m");
@@ -24,6 +26,78 @@
             assert.equal(result[6], "\u001b[33mThis is pending\u001b[39m");
             assert.equal(result[7], "\u001b[90mline\u001b[39m");
 
+        });
+        it("show failed only when selected", function() {
+            var input = {
+                passed: [{"This has passed" : "line"}, {"This Suite": {"has also passed": "line"}}],
+                failed: [{"This has failed" : "line"}],
+                pending: [{"This is pending" : "line"}]
+            }, config = {
+                "outputDetails": ["passed","pending"]
+            },
+            result = spitterOuter(input,config);
+
+            assert.equal(result.length,6);
+            
+            assert.equal(result[0], "\u001b[32mThis has passed\u001b[39m");
+            assert.equal(result[1], "\u001b[90mline\u001b[39m");
+
+            assert.equal(result[2], "\u001b[32mThis Suite has also passed\u001b[39m");
+            assert.equal(result[3], "\u001b[90mline\u001b[39m");
+
+            assert.equal(result[4], "\u001b[33mThis is pending\u001b[39m");
+            assert.equal(result[5], "\u001b[90mline\u001b[39m");
+        });
+        it("show passed only when selected", function() {
+            var input = {
+                        passed: [{"This has passed": "line"}, {"This Suite": {"has also passed": "line"}}],
+                        failed: [{"This has failed": "line"}],
+                        pending: [{"This is pending": "line"}]
+                    }, config = {
+                        "outputDetails": ["failed", "pending"]
+                    }, result = spitterOuter(input, config);
+
+            assert.equal(result.length, 4);
+            
+            assert.equal(result[0], "\u001b[31mThis has failed\u001b[39m");
+            assert.equal(result[1], "\u001b[90mline\u001b[39m");
+
+            assert.equal(result[2], "\u001b[33mThis is pending\u001b[39m");
+            assert.equal(result[3], "\u001b[90mline\u001b[39m");
+
+        });
+        it("show pending only when selected", function() {
+            var input = {
+                        passed: [{"This has passed": "line"}, {"This Suite": {"has also passed": "line"}}],
+                        failed: [{"This has failed": "line"}],
+                        pending: [{"This is pending": "line"}]
+                    }, config = {
+                        "outputDetails": ["failed", "passed"]
+                    }, result = spitterOuter(input, config);
+
+            assert.equal(result.length, 6);
+            
+            assert.equal(result[0], "\u001b[32mThis has passed\u001b[39m");
+            assert.equal(result[1], "\u001b[90mline\u001b[39m");
+
+            assert.equal(result[2], "\u001b[32mThis Suite has also passed\u001b[39m");
+            assert.equal(result[3], "\u001b[90mline\u001b[39m");
+
+            assert.equal(result[4], "\u001b[31mThis has failed\u001b[39m");
+            assert.equal(result[5], "\u001b[90mline\u001b[39m");
+
+        });
+        it("show nothing when no options selected", function() {
+            var input = {
+                        passed: [{"This has passed": "line"}, {"This Suite": {"has also passed": "line"}}],
+                        failed: [{"This has failed": "line"}],
+                        pending: [{"This is pending": "line"}]
+                    }, config = {
+                        "outputDetails": []
+                    }, result = spitterOuter(input, config);
+
+            assert.equal(result.length, 0);
+            
         });
     });
 })(require);

--- a/test/summariserSpec.js
+++ b/test/summariserSpec.js
@@ -1,0 +1,24 @@
+(function(require){
+
+    var summariser = require('../lib/summariser'),
+        assert = require('assert');
+
+    describe("Summmariser", function() {
+        it("summarise and colorise results into an array of console messages", function() {
+            var input = {
+                passed: [{"This has passed" : "line"}, {"This Suite": {"has also passed": "line"}}],
+                failed: [{"This has failed" : "line"}],
+                pending: [{"This is pending" : "line"}]
+            },
+            result = summariser(input);
+
+            assert.equal(result.length, 4);
+            
+            assert.equal(result[0], "\u001b[1m4 Specs defined\u001b[22m");
+            assert.equal(result[1], "\u001b[32m2 Passed (50.0%)\u001b[39m");
+            assert.equal(result[2], "\u001b[31m1 Failed (25.0%)\u001b[39m");
+            assert.equal(result[3], "\u001b[33m1 Pending (25.0%)\u001b[39m");
+
+        });
+    });
+})(require);


### PR DESCRIPTION
We have a large number of features and specs so the output can get a little overwhelming. 

Output control has been added in 2 config options outputDetails and outputSummary;

**outputDetails**
Specify which categories to show in the details output eg --outputDetails="failed,pending" will hide anything that is passing.

**outputSummary**
Display a summary at the end of the process to get some statistics across all test sources.

![image](https://cloud.githubusercontent.com/assets/647701/6732194/0024392e-ce42-11e4-826f-885a5611f166.png)
