### PR TITLE
Result watching bugs

### DIFF
--- a/lib/formats/junitConverter.js
+++ b/lib/formats/junitConverter.js
@@ -110,12 +110,14 @@ junitConverter.prototype = {
             result;
 
         this.parser.parseString(data, function (err, result) {
-            if (result.testsuite) {
-                result = this.parseTestSuite(result.testsuite);
-            }
-            if (result.testsuites) {
-                result = this.parseTestSuites(result.testsuites);
-            }
+            if( result ) {
+                if(result.testsuite) {
+                    result = this.parseTestSuite(result.testsuite);
+                }
+                if(result.testsuites) {
+                    result = this.parseTestSuites(result.testsuites);
+                }
+            }   
             callback(result);
         }.bind(this));
     }

--- a/lib/resultCollector.js
+++ b/lib/resultCollector.js
@@ -27,7 +27,12 @@ function collectResults(resultsGlob, callback) {
             converter = new JunitConverter(files[i]);
             converter.exec(converterCallback);
         } else {
-            result = JSON.parse(fs.readFileSync(files[i]));
+            try {
+                result = JSON.parse(fs.readFileSync(files[i]));
+            } catch (err){
+                console.log('Error parsing JSON of '+files[i]);
+                result = {};
+            }
         }
         response = mergeResults(result, response);
         count++;

--- a/test/fixtures/multiple_results/resultsInvalidJson.json
+++ b/test/fixtures/multiple_results/resultsInvalidJson.json
@@ -1,0 +1,11 @@
+{
+    "Results1": {
+        "should be able to merge tests": "PASSED"
+    },
+    "Results2": {
+        "should be able to other context based tests": "PASSED"
+    },
+    "ResultsInvalid": {
+
+    
+}


### PR DESCRIPTION
Fixed error thrown when watched results files are emptied or locked by testing process which interrupted watching.

Fixed #1 Syntax error when invalid JSON is supplied
