### PR TITLE
Merged feature structure

### DIFF
--- a/lib/markdownParser.js
+++ b/lib/markdownParser.js
@@ -16,7 +16,7 @@ function parseMarkdown(file, tags, callback) {
             tokens: ['+'],
             match: function(line) {
                 for(var i = 0; i < this.tokens.length; i++) {
-                    var regex = new RegExp('\\' + this.tokens[i] + ' ([^\n]*)');
+                    var regex = new RegExp('\\' + this.tokens[i] + ' ([^\r\n]*)');
                     if(line.match(regex)) {
                         return line.match(regex);
                     }
@@ -32,7 +32,7 @@ function parseMarkdown(file, tags, callback) {
             tokens: ['#'],
             match: function(line) {
                 for(var i = 0; i < this.tokens.length; i++) {
-                    var regex = new RegExp('\\' + this.tokens[i] + ' ([^\n]*)');
+                    var regex = new RegExp('\\' + this.tokens[i] + ' ([^\r\n]*)');
                     if(line.match(regex)) {
                         return line.match(regex);
                     }
@@ -50,7 +50,7 @@ function parseMarkdown(file, tags, callback) {
             tokens: ['> skip', '>skip'],
             match: function(line) {
                 for(var i = 0; i < this.tokens.length; i++) {
-                    var regex = new RegExp('\\' + this.tokens[i] + '([^\n]*)', 'i');
+                    var regex = new RegExp('\\' + this.tokens[i] + '([^\r\n]*)', 'i');
                     if(line.match(regex)) {
                         return line.match(regex);
                     }
@@ -62,7 +62,7 @@ function parseMarkdown(file, tags, callback) {
             tokens: ['> @', '>@'],
             match: function(line) {
                 for(var i = 0; i < this.tokens.length; i++) {
-                    var regex = new RegExp('\\' + this.tokens[i] + '([^\n]*)');
+                    var regex = new RegExp('\\' + this.tokens[i] + '([^\r\n]*)');
                     if(line.match(regex)) {
                         return line.match(regex);
                     }

--- a/lib/specCollector.js
+++ b/lib/specCollector.js
@@ -1,6 +1,8 @@
 /**
  * Get the specs from a glob and merges the specs
  */
+var merge = require("merge");
+
  function collectSpecs(specsGlob, tags, callback) {
     var featureTransformer = require('./featureTransformer'),
         glob = require("glob"),
@@ -30,7 +32,11 @@ function mergeSpecs(spec, response) {
     spec = JSON.parse(spec);
     for(var key in spec) {
         if (spec.hasOwnProperty(key)) {
-            response[key] = spec[key];
+            if( response.hasOwnProperty(key) ){
+               response[key] = merge.recursive(response[key],spec[key]);
+            } else {
+                response[key] = spec[key];
+            }
         }
     }
     return response;

--- a/lib/visualiser/viewBuilder.js
+++ b/lib/visualiser/viewBuilder.js
@@ -2,6 +2,7 @@
  * Creates fresh heirarchy from files
  */
 function viewBuilder(contexts, joins) {
+  var merge = require('merge');
   var heirarchy = {};
   var graph = {
     nodes: [],
@@ -57,15 +58,23 @@ function viewBuilder(contexts, joins) {
     addLink(parent, nodeIndex);
   }
 
+  function createNode(name, specs) {
+    return {
+      name: name, 
+      shoulds: specs, 
+      depth: depth, 
+      key: fullContext.match(new RegExp(name+'$')) ? fullContext : name
+    };
+  }
+
   function addNode(name, specs) {
     var index = graph.nodes.length;
-    graph.nodes.push({
-      name: name,
-      shoulds: specs,
-      depth: depth,
-      key: fullContext.match(new RegExp(name + '$'))? fullContext : name
-    });
+    graph.nodes.push(createNode(name, specs));
     return index;
+  }
+  
+  function mergeNode(index, name, specs) {
+    graph.nodes[index] = merge.recursive(graph.nodes[index],createNode(name,specs));
   }
 
   function addLink(source, target) {
@@ -84,18 +93,23 @@ function viewBuilder(contexts, joins) {
   function traverseMap(map, parents, node) {
     depth++;
     var mapPointer = map[parents[0]];
-    if (mapPointer) {
+    if ( mapPointer && parents.length > 1) {
       parents.splice(0, 1);
       return traverseMap(mapPointer, parents, node);
-    }
+    } 
     var currentContext = parents[0];
     mapPointer = map;
-    mapPointer[currentContext] = {
-      '_index': addNode(currentContext, (parents.length > 1)? [] : node.specs)
-    };
-    if (map._index !== undefined) {
-      addLink(map._index, mapPointer[currentContext]._index);
+    if( mapPointer.hasOwnProperty(currentContext)){
+      mergeNode(mapPointer[currentContext]['_index'],currentContext, node.specs)
+    } else {
+      mapPointer[currentContext] = {
+        '_index': addNode(currentContext, (parents.length > 1) ? [] : node.specs)
+      };
+      if(map._index !== undefined) {
+        addLink(map._index, mapPointer[currentContext]._index);
+      }
     }
+
     if (parents.length > 1) {
       parents.splice(0, 1);
       return traverseMap(mapPointer[currentContext], parents, node);

--- a/lib/visualiser/viewBuilder.js
+++ b/lib/visualiser/viewBuilder.js
@@ -100,7 +100,7 @@ function viewBuilder(contexts, joins) {
     var currentContext = parents[0];
     mapPointer = map;
     if( mapPointer.hasOwnProperty(currentContext)){
-      mergeNode(mapPointer[currentContext]['_index'],currentContext, node.specs)
+      mergeNode(mapPointer[currentContext]._index,currentContext, node.specs);
     } else {
       mapPointer[currentContext] = {
         '_index': addNode(currentContext, (parents.length > 1) ? [] : node.specs)

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "minimist": "~0.2.0",
     "xml2js": "~0.4.1",
     "xmlbuilder": "~2.1.0",
-    "yamljs": "^0.2.1"
+    "yamljs": "^0.2.1",
+    "merge": "1.2.0"
   },
   "homepage": "https://github.com/bbc-sport/ShouldIT",
   "directories": {

--- a/test/specCollectorSpec.js
+++ b/test/specCollectorSpec.js
@@ -58,3 +58,87 @@ describe("Spec collector", function() {
         
     });
 });
+
+describe("Spec collector", function() {
+    var calls = [], transformerSpy, globStub, specCollector, i;
+
+    beforeEach(function() {
+        i = 0;
+        var object, transformer = function(file, tags, callback) {
+                    i++;
+                    switch(i) {
+                        case 1:
+                            object = {
+                                "top middle bottom": {
+                                    "_parents": ["top", "middle", "bottom"], "specs": {
+                                        "should bottom 1": "test/fixtures/markdown/describe.md:2",
+                                        "should bottom 2": "test/fixtures/markdown/describe.md:3"
+                                    }
+                                }
+                            };
+                            break;
+                        case 2:
+                            object = {
+                                "top middle": {
+                                    "_parents": ["top", "middle"], "specs": {
+                                        "should middle": "test/fixtures/markdown/describe.md:2",
+                                        "should middle 2": "test/fixtures/markdown/describe.md:3"
+                                    }
+                                }
+                            };
+                            break;
+                        case 3:
+                            object = {
+                                "top middle": {
+                                    "_parents": ["top", "middle"], "specs": {
+                                        "should middle 3": "test/fixtures/markdown/describe2.md:3",
+                                        "should middle 4": "test/fixtures/markdown/describe2.md:4"
+                                    }
+                                }
+                            };
+                            break;
+                    }
+
+                    callback(JSON.stringify(object));
+                }
+        mockery.enable();
+        mockery.warnOnReplace(false);
+        mockery.warnOnUnregistered(false);
+        transformerSpy = sinon.spy(transformer);
+
+        globStub = function(glob, options, callback) {
+            callback(null, [1, 2, 3]);
+        };
+        mockery.registerMock('./featureTransformer', transformerSpy);
+        mockery.registerMock('glob', globStub);
+        specCollector = require('../lib/specCollector');
+
+    });
+
+    afterEach(function() {
+        calls = [];
+        mockery.disable();
+    });
+
+    it("should merge structures", function(done) {
+        specCollector('test/fixtures/markdown/*.md', [], function(data) {
+            assert.equal(JSON.stringify(data), JSON.stringify({
+                "top middle bottom": {
+                    "_parents": ["top", "middle", "bottom"], "specs": {
+                        "should bottom 1": "test/fixtures/markdown/describe.md:2",
+                        "should bottom 2": "test/fixtures/markdown/describe.md:3"
+                    }
+                }, "top middle": {
+                    "_parents": ["top", "middle"], "specs": {
+                        "should middle": "test/fixtures/markdown/describe.md:2",
+                        "should middle 2": "test/fixtures/markdown/describe.md:3",
+                        "should middle 3": "test/fixtures/markdown/describe2.md:3",
+                        "should middle 4": "test/fixtures/markdown/describe2.md:4"
+                    }
+                }
+            }));
+            done();
+        });
+
+    });
+});


### PR DESCRIPTION
Not sure if this is a genuine bug or we're using it in a way it was never intended.

We're structuring our specifications partially in line with our application structure with each features split across multiple feature definition files. I've noticed that if 2 features define two parts of the same structure only one will be included in the spec-file.json. I've managed to overcome this issue using the 'merge' package. 

**Feature 1**

```markdown
# Api

## Customer

+ IT should allow view when authenticated

### View

Scenario : Get customer record detail

+ IT should not show a customer without a group hash
```

**Feature 2**

```markdown
# Api

## Customer

Scenario : List customer records for a specific group

+ IT should not show any customers without a group hash
```

**Previous Result**

```JSON
{
    "Api Customer": {
        "_parents": [
            "Api",
            "Customer"
        ],
        "specs": {
            "should allow view when authenticated": "_specs/api/1.feature.md:7"
        }
    },
    "Api Customer View": {
        "_parents": [
            "Api",
            "Customer",
            "View"
        ],
        "specs": {
            "should not show a customer without a group hash": "_specs/api/1.feature.md:13"
        }
    }
}
```
**Result after changes**
```JSON
{
    "Api Customer": {
        "_parents": [
            "Api",
            "Customer"
        ],
        "specs": {
            "should not show any customers without a group hash": "_specs/api/2.feature.md:7",
            "should allow view when authenticated": "_specs/api/1.feature.md:7"
        }
    },
    "Api Customer View": {
        "_parents": [
            "Api",
            "Customer",
            "View"
        ],
        "specs": {
            "should not show a customer without a group hash": "_specs/api/1.feature.md:13"
        }
    }
}
```